### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/samkeen/babel-bridge/compare/v0.2.1...v0.2.2) - 2024-04-27
+
+### Other
+- .gitignore cleanup
+- Merge branch 'main' into release-plz-2024-04-27T19-50-08Z
+- release
+
 ## [0.2.1](https://github.com/samkeen/babel-bridge/compare/v0.2.0...v0.2.1) - 2024-04-27
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "babel-bridge"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dotenv",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "babel-bridge"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Sam Keen <sam.sjk@gmail.com>"]
 description = "SDK for interacting with various Large Language Model (LLM) APIs"


### PR DESCRIPTION
## 🤖 New release
* `babel-bridge`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/samkeen/babel-bridge/compare/v0.2.1...v0.2.2) - 2024-04-27

### Other
- .gitignore cleanup
- Merge branch 'main' into release-plz-2024-04-27T19-50-08Z
- release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).